### PR TITLE
Simplify Dockerfile, change to Debian

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,18 +2,12 @@ name: Create and publish a Docker image
 
 on:
   workflow_dispatch:
-    inputs:
-      UbuntuVersion:
-        description: "Ubuntu Version"
-        default: "24.04"
-        required: true
   push:
     tags:
       - 'v[0-9]+.[0-9]+'
 
 env:
   REGISTRY: ghcr.io
-  UBUNTU: ${{ inputs.UbuntuVersion || vars.UBUNTU_VERSION }}
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -41,8 +35,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
-          flavor: suffix=-u${{ env.UBUNTU }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=match,pattern=v(\d.\d),group=1
+            type=ref,event=pr
 
       - name: Build and push Docker image
         id: push
@@ -51,7 +49,6 @@ jobs:
           context: .
           push: true
           no-cache: true
-          build-args: UBUNTU_VERSION=${{ env.UBUNTU }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           context: .
           push: true
           no-cache: true
+          build-args: ENV_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM debian:bookworm-slim
 
 SHELL ["/bin/bash", "-c"]
 
+ARG ENV_VERSION
+ENV ENV_VERSION=${ENV_VERSION}
 ENV BASH_ENV=/etc/profile
 ENV VIRTUAL_ENV=/opt/apes/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV FC=mpif90
 
 RUN apt update && apt upgrade -y && \
@@ -19,7 +22,6 @@ RUN apt update && apt upgrade -y && \
       python3-full \
       python3-pip
 
-RUN python3 -m venv --system-site-packages $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN $VIRTUAL_ENV/bin/pip install -r requirements.txt
+RUN python3 -m venv --system-site-packages $VIRTUAL_ENV && \
+    $VIRTUAL_ENV/bin/pip install -r requirements.txt
 COPY helper/env-freeze $VIRTUAL_ENV/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt update && apt upgrade -y && \
       python3-full \
       python3-pip
 
+COPY requirements.txt /tmp/
 RUN python3 -m venv --system-site-packages $VIRTUAL_ENV && \
-    $VIRTUAL_ENV/bin/pip install -r requirements.txt
+    $VIRTUAL_ENV/bin/pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
 COPY helper/env-freeze $VIRTUAL_ENV/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-ARG UBUNTU_VERSION=latest
-FROM ubuntu:${UBUNTU_VERSION}
+FROM debian:bookworm-slim
 
 SHELL ["/bin/bash", "-c"]
 
 ENV BASH_ENV=/etc/profile
+ENV VIRTUAL_ENV=/opt/apes/venv
+ENV FC=mpif90
 
 RUN apt update && apt upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt install -y \
@@ -18,13 +19,7 @@ RUN apt update && apt upgrade -y && \
       python3-full \
       python3-pip
 
-RUN useradd apes
-USER apes
-ENV APES_HOME=/home/apes
-WORKDIR $APES_HOME
-COPY requirements.txt ./
-ENV VIRTUAL_ENV=$APES_HOME/venv
 RUN python3 -m venv --system-site-packages $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN $VIRTUAL_ENV/bin/pip install -r requirements.txt
-CMD ["/bin/bash", "-i"]
+COPY helper/env-freeze $VIRTUAL_ENV/bin/


### PR DESCRIPTION
Define the base image in Dockerfile, don't allow it to be changed via the workflow.
We only employ Debian as recommended in the github actions documentation, and the base image to be used is part of the release, this should avoid confusions.